### PR TITLE
Setting git-dir and work-tree

### DIFF
--- a/clone-hook
+++ b/clone-hook
@@ -42,7 +42,7 @@ def git_exists?(template_dir)
 end
 
 def origin_exists?(template_dir)
-  `git -C #{template_dir} remote show origin`
+  `git --git-dir #{template_dir}/.git --work-tree #{template_dir} remote show origin`
   $?.success?
 end
 
@@ -64,7 +64,7 @@ end
 
 def update_templates(git_url, dest, branch='master')
   create_repo(dest, git_url, branch)
-  puts `git -C #{dest} pull` if perform_update?
+  puts `git --git-dir #{dest}/.git --work-tree #{dest} pull` if perform_update?
   dest
 end
 


### PR DESCRIPTION
When using retrospec, I get the following error message:

```
Unknown option: -C
usage: git [--version] [--exec-path[=GIT_EXEC_PATH]] [--html-path]
           [-p|--paginate|--no-pager] [--no-replace-objects]
           [--bare] [--git-dir=GIT_DIR] [--work-tree=GIT_WORK_TREE]
           [--help] COMMAND [ARGS]
Successfully ran hook: /root/.retrospec/repos/retrospec-puppet-templates/clone-hook
```

The hook is attempting to use the `-C` flag to set the current working directory and run commands remotely.  I've instead changed this to `git-dir` and `work-tree` to it works correctly.
