### PR TITLE
Change Gemfile to use PUPPET_GEM_VERSION

### DIFF
--- a/module_files/Gemfile
+++ b/module_files/Gemfile
@@ -2,7 +2,7 @@ source "https://rubygems.org"
 
 group :test do
     gem "rake"
-    gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.8.3'
+    gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.3'
     gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
     gem "puppetlabs_spec_helper"
     gem 'rspec-puppet-utils', :git => 'https://github.com/Accuity/rspec-puppet-utils.git'


### PR DESCRIPTION
PUPPET_GEM_VERSION is used both in the .travis.yml file, as well as across other modules.
